### PR TITLE
Update colours to work with Nova 4

### DIFF
--- a/src/LogsService.php
+++ b/src/LogsService.php
@@ -15,15 +15,15 @@ class LogsService
     private static string $file;
 
     private static array $levels_classes = [
-        'debug'     => 'text-blue',
-        'info'      => 'text-blue',
-        'notice'    => 'text-blue',
-        'warning'   => 'text-orange',
-        'error'     => 'text-red',
-        'critical'  => 'text-red',
-        'alert'     => 'text-red',
-        'emergency' => 'text-red',
-        'processed' => 'text-blue',
+        'debug'     => 'text-blue-500',
+        'info'      => 'text-blue-500',
+        'notice'    => 'text-blue-500',
+        'warning'   => 'text-yellow-500',
+        'error'     => 'text-red-500',
+        'critical'  => 'text-red-500',
+        'alert'     => 'text-red-500',
+        'emergency' => 'text-red-500',
+        'processed' => 'text-blue-500',
     ];
 
     private static array $levels_imgs = [


### PR DESCRIPTION
Nova 4 uses Tailwind in JIT mode. As a result of this only colours used by Nova are present in the stylesheet.

This commit updates the colours used by this tool to ones that are present in the Nova stylesheet.