### PR TITLE
feat: added the nova:api middleware on api routes registration

### DIFF
--- a/src/LogsToolServiceProvider.php
+++ b/src/LogsToolServiceProvider.php
@@ -26,7 +26,7 @@ class LogsToolServiceProvider extends ServiceProvider
             return;
         }
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', 'nova:api', Authorize::class])
             ->prefix('nova-vendor/stepanenko3/logs-tool')
             ->group(__DIR__ . '/../routes/api.php');
     }


### PR DESCRIPTION
## The issue:

API routes are open to everyone. So everyone can download the log files and see it.
https://github.com/stepanenko3/nova-logs-tool/issues/25

## Explanation:

Default behavior on Nova tools is that routes inside api are not protected. Please find the related discussion in nova-issues.
The solution is to add the middleware `nova:api`.

https://github.com/laravel/nova-issues/discussions/5496