### PR TITLE
[3.x] Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0.0",
+        "php": ">=8.2.0",
         "laravel/nova": "^5.0",
         "stepanenko3/laravel-log-viewer": "*"
     },


### PR DESCRIPTION
Proposing to make a major release because both Laravel 12 and Nova 5 requires **PHP 8.2**.

Seems to be the only thing needed for updating.

Tested it with **Laravel 12, Nova 5 and PHP 8.2**

Let me know if im missing something @stepanenko3 